### PR TITLE
fix test_train_split function in evaluation/protocol

### DIFF
--- a/ampligraph/evaluation/protocol.py
+++ b/ampligraph/evaluation/protocol.py
@@ -102,7 +102,7 @@ def train_test_split_no_unseen(X, test_size=5000, seed=0, allow_duplication=Fals
     tolerance = len(X) * 10
     while idx_test.shape[0] < test_size:
         i = rnd.randint(len(X))
-        if dict_subs[X[i, 0]] > 1 and dict_objs[X[i, 2]] > 1 and dict_rels[X[i,1]] > 1:
+        if dict_subs[X[i, 0]] > 0 and dict_objs[X[i, 2]] > 0 and dict_rels[X[i,1]] > 0:
             dict_subs[X[i, 0]] -= 1
             dict_objs[X[i, 2]] -= 1
             dict_rels[X[i, 1]] -= 1

--- a/tests/ampligraph/evaluation/test_protocol.py
+++ b/tests/ampligraph/evaluation/test_protocol.py
@@ -436,7 +436,7 @@ def test_train_test_split():
 
     # Graph
     X = np.array([['a', 'y', 'b'],
-                  ['a', 'y', 'c'],
+                  ['x', 'y', 'c'],
                   ['c', 'y', 'a'],
                   ['d', 'y', 'e'],
                   ['e', 'y', 'f'],
@@ -444,12 +444,12 @@ def test_train_test_split():
                   ['f', 'y', 'c']])
 
     expected_X_train = np.array([['a', 'y', 'b'],
+                                ['x', 'y', 'c'],
                                 ['c', 'y', 'a'],
                                 ['d', 'y', 'e'],
-                                ['e', 'y', 'f'],
                                 ['f', 'y', 'c']])
     
-    expected_X_test = np.array([['a', 'y', 'c'],
+    expected_X_test = np.array([['e', 'y', 'f'],
                                 ['f', 'y', 'c']])
 
     X_train, X_test = train_test_split_no_unseen(X, test_size = 2, seed = 0)


### PR DESCRIPTION
#### Related Issue(s)
Fixes: "Train test split overflow" #90

#### Description of Changes
```
diff --git a/ampligraph/evaluation/protocol.py b/ampligraph/evaluation/protocol.py
@@ -102,7 +102,7 @@ def train_test_split_no_unseen(X, test_size=5000, seed=0, allow_duplication=Fals
     tolerance = len(X) * 10
     while idx_test.shape[0] < test_size:
         i = rnd.randint(len(X))
-        if dict_subs[X[i, 0]] > 1 and dict_objs[X[i, 2]] > 1 and dict_rels[X[i,1]] > 1:
+        if dict_subs[X[i, 0]] > 0 and dict_objs[X[i, 2]] > 0 and dict_rels[X[i,1]] > 0:
             dict_subs[X[i, 0]] -= 1
             dict_objs[X[i, 2]] -= 1
             dict_rels[X[i, 1]] -= 1
```
and fixed tests.
