### PR TITLE
Remove unnecessary HashTable(table_filter_lookup) for saving memory

### DIFF
--- a/ampligraph/evaluation/protocol.py
+++ b/ampligraph/evaluation/protocol.py
@@ -223,7 +223,7 @@ def generate_corruptions_for_eval(X, entities_for_corruption, corrupt_side='s+o'
     out : Tensor, shape [n, 3]
         An array of corruptions for the triples for x.
         
-    out_prime : Tensor, shape [n, 3]
+    out_prime : Tensor, shape [n]
         An array of product of prime numbers associated with corruption triples or None 
         based on filtered or non filtered version.
 


### PR DESCRIPTION
There are two changes in this PR
+ Fixed a typo in the docstring for function  `generate_corruptions_for_eval`. The return shape of `out_prime`  should be `[n]` rather than `[n, 3]`
+ `HashTables `and `lookup` in the model are not necessary. This PR deprecated the `table_filter_lookup`, but other 3 hash tables could also be deprecated.