### PR TITLE
CircleCI integration for tests and checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,87 @@
+.common-values:
+
+  docker-image: &docker-image circleci/python:3.6.4
+
+  restore-cache: &restore-cache
+    keys:
+      - v1-dependencies-{{ checksum "setup.py" }}-{{ checksum "requirements.txt" }}
+
+  create-venv: &create-venv
+    name: Create virtualenv
+    command: /usr/local/bin/python3 -m venv venv
+
+  save-cache: &save-cache
+    paths:
+      - ./venv
+    key: v1-dependencies-{{ checksum "setup.py" }}-{{ checksum "requirements.txt" }}
+
+  install-package: &install-package
+    name: Install package
+    command: |
+      . venv/bin/activate
+      venv/bin/python3 -m pip install .
+
+version: 2
+jobs:
+  build:
+    docker:
+      - image: *docker-image
+    steps:
+    - checkout
+    - restore_cache: *restore-cache
+    - run: *create-venv
+    - save_cache: *save-cache
+    - run: *install-package
+
+  pip-check:
+    docker:
+      - image: *docker-image
+    steps:
+    - checkout
+    - restore_cache: *restore-cache
+    - run: *create-venv
+    - save_cache: *save-cache
+    - run: *install-package
+    - run:
+        name: Pip check
+        command: |
+          . venv/bin/activate
+          venv/bin/python3 -m pip check
+
+  test:
+    docker:
+      - image: *docker-image
+    steps:
+    - checkout
+    - restore_cache: *restore-cache
+    - run: *create-venv
+    - save_cache: *save-cache
+    - run: *install-package
+    - run:
+          name: Install Python dependencies in a venv
+          command: |
+            . venv/bin/activate
+            venv/bin/python3 -m pytest tests
+  lint:
+    docker:
+      - image: *docker-image
+    steps:
+    - checkout
+    - restore_cache: *restore-cache
+    - run: *create-venv
+    - save_cache: *save-cache
+    - run:
+          name: linting with flake8
+          command: |
+            . venv/bin/activate
+            venv/bin/python3 -m pip install flake8
+            venv/bin/python3 -m flake8 ampligraph --max-line-length 120 --ignore=W291,W293
+
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - build
+      - test
+      - pip-check
+      - lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@
     command: |
       . venv/bin/activate
       venv/bin/python3 -m pip install .
+      venv/bin/python3 -m pip install tensorflow==1.13.1
 
 version: 2
 jobs:
@@ -85,6 +86,7 @@ jobs:
     - restore_cache: *restore-cache
     - run: *create-venv
     - save_cache: *save-cache
+    - run: *install-package
     - run:
           name: Making docs with Sphinx
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,10 +98,10 @@ jobs:
 
 workflows:
   version: 2
-  build_and_test:
+  checks:
     jobs:
       - build
-      - test
       - pip-check
       - lint
       - docs
+      - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,3 +102,4 @@ workflows:
       - test
       - pip-check
       - lint
+      - docs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
     - save_cache: *save-cache
     - run: *install-package
     - run:
-          name: Install Python dependencies in a venv
+          name: Unit tests with Pytest
           command: |
             . venv/bin/activate
             venv/bin/python3 -m pytest tests
@@ -71,11 +71,28 @@ jobs:
     - run: *create-venv
     - save_cache: *save-cache
     - run:
-          name: linting with flake8
+          name: Linting with flake8
           command: |
             . venv/bin/activate
             venv/bin/python3 -m pip install flake8
             venv/bin/python3 -m flake8 ampligraph --max-line-length 120 --ignore=W291,W293
+
+  docs:
+    docker:
+      - image: *docker-image
+    steps:
+    - checkout
+    - restore_cache: *restore-cache
+    - run: *create-venv
+    - save_cache: *save-cache
+    - run:
+          name: Making docs with Sphinx
+          command: |
+            . venv/bin/activate
+            venv/bin/python3 -m pip install sphinx
+            cd docs
+            make clean autogen html
+
 
 workflows:
   version: 2

--- a/ampligraph/latent_features/loss_functions.py
+++ b/ampligraph/latent_features/loss_functions.py
@@ -468,7 +468,7 @@ class SelfAdversarialLoss(Loss):
 class NLLMulticlass(Loss):
     r"""Multiclass NLL Loss.
     
-    Introduced in :cite:`chen2015` where both the subject and objects are corrupted (to use it in this way pass sddddddddddddd
+    Introduced in :cite:`chen2015` where both the subject and objects are corrupted (to use it in this way pass
     corrupt_sides = ['s', 'o'] to embedding_model_params) .
 
     This loss was re-engineered in :cite:`kadlecBK17` where only the object was corrupted to get improved

--- a/ampligraph/latent_features/loss_functions.py
+++ b/ampligraph/latent_features/loss_functions.py
@@ -468,7 +468,7 @@ class SelfAdversarialLoss(Loss):
 class NLLMulticlass(Loss):
     r"""Multiclass NLL Loss.
     
-    Introduced in :cite:`chen2015` where both the subject and objects are corrupted (to use it in this way pass
+    Introduced in :cite:`chen2015` where both the subject and objects are corrupted (to use it in this way pass sddddddddddddd
     corrupt_sides = ['s', 'o'] to embedding_model_params) .
 
     This loss was re-engineered in :cite:`kadlecBK17` where only the object was corrupted to get improved

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,8 @@ setup_params = dict(name='ampligraph',
                         'rdflib>=4.2.2',
                         'scipy>=1.3.0',
                         'networkx>=2.3',
-                        'flake8>=3.7.7'
+                        'flake8>=3.7.7',
+                        'setuptools>=36'
                     ])
 if __name__ == '__main__':
     setup(**setup_params)


### PR DESCRIPTION
#### Related Issue(s)
#127 

#### Description of Changes
Adding CircleCI config file including checks for:
1. Build (pip install)
2. Unit tests
3. Pip check
4. Linting with flake8
5. Make docs with Sphinx

#### Any other comments?
When you open a PR, now you can see whether the tests and checks are passing / failing!

Alternatively, you can create a CircleCI account with your Github account and start following AmpliGraph there, so you can go to https://circleci.com/gh/Accenture/AmpliGraph and see all the running builds and tests (you also get an email if there is a failure from your commit).

