### PR TITLE
Fixing discrepancy in batch count

### DIFF
--- a/ampligraph/datasets/abstract_dataset_adapter.py
+++ b/ampligraph/datasets/abstract_dataset_adapter.py
@@ -89,15 +89,15 @@ class AmpligraphDatasetAdapter(abc.ABC):
         """
         raise NotImplementedError('Abstract Method not implemented!')
         
-    def get_next_train_batch(self, batch_size=1, dataset_type="train"):
+    def get_next_train_batch(self, batches_count, dataset_type="train"):
         """Generator that returns the next batch of data.
         
         Parameters
         ----------
-        batch_size : int
-            data size that needs to be returned
         dataset_type: string
             indicates which dataset to use
+        batches_count: int
+            number of batches per epoch
         Returns
         -------
         batch_output : nd-array

--- a/ampligraph/datasets/numpy_adapter.py
+++ b/ampligraph/datasets/numpy_adapter.py
@@ -55,16 +55,15 @@ class NumpyDatasetAdapter(AmpligraphDatasetAdapter):
         """
         return self.dataset[dataset_type].shape[0]
     
-    def get_next_train_batch(self, batch_size=1, dataset_type="train"):
+    def get_next_train_batch(self, batches_count, dataset_type="train"):
         """Generator that returns the next batch of data.
         
         Parameters
         ----------
-        batch_size : int
-            data size that needs to be returned
         dataset_type: string
             indicates which dataset to use
-        Returns
+        batches_count: int
+            number of batches per epochReturns
         -------
         batch_output : nd-array
             yields a batch of triples from the dataset type specified
@@ -72,8 +71,9 @@ class NumpyDatasetAdapter(AmpligraphDatasetAdapter):
         # if data is not already mapped, then map before returning the batch
         if not self.mapped_status[dataset_type]:
             self.map_data()
-            
-        batches_count = int(np.ceil(self.get_size(dataset_type) / batch_size))
+
+        batch_size = int(np.ceil(self.get_size(dataset_type) / batches_count))
+
         for i in range(batches_count):
             out = np.int32(self.dataset[dataset_type][(i * batch_size):((i + 1) * batch_size), :])
             yield out

--- a/ampligraph/datasets/sqlite_adapter.py
+++ b/ampligraph/datasets/sqlite_adapter.py
@@ -160,15 +160,15 @@ class SQLiteAdapter(AmpligraphDatasetAdapter):
         cur1.close()
         return out[0][0]
     
-    def get_next_train_batch(self, batch_size, dataset_type="train"):
+    def get_next_train_batch(self, batches_count, dataset_type="train"):
         """Generator that returns the next batch of data.
         
         Parameters
         ----------
-        batch_size : int
-            data size that needs to be returned
         dataset_type: string
             indicates which dataset to use
+        batches_count: int
+            number of batches per epoch
         Returns
         -------
         batch_output : nd-array
@@ -177,8 +177,8 @@ class SQLiteAdapter(AmpligraphDatasetAdapter):
         if (not self.using_existing_db) and (not self.mapped_status[dataset_type]):
             self.map_data()
         
-        # create batches directly from database
-        batches_count = int(np.ceil(self.get_size(dataset_type) / batch_size))
+        batch_size = int(np.ceil(self.get_size(dataset_type) / batches_count))
+
         select_query = "SELECT subject, predicate,object FROM triples_table INDEXED BY \
                             triples_table_type_idx where dataset_type ='{}' LIMIT {}, {}"
         for i in range(batches_count):

--- a/ampligraph/latent_features/models/EmbeddingModel.py
+++ b/ampligraph/latent_features/models/EmbeddingModel.py
@@ -771,7 +771,7 @@ class EmbeddingModel(abc.ABC):
         # generate empty embeddings for smaller graphs - as all the entity embeddings will be loaded on GPU
         entity_embeddings = np.empty(shape=(0, self.internal_k), dtype=np.float32)
         # create iterator to iterate over the train batches
-        batch_iterator = iter(self.train_dataset_handle.get_next_train_batch(self.batch_size, "train"))
+        batch_iterator = iter(self.train_dataset_handle.get_next_train_batch(self.batches_count, "train"))
         for i in range(self.batches_count):
             out = next(batch_iterator)
             # If large graph, load batch_size*2 entities on GPU memory
@@ -1495,9 +1495,7 @@ class EmbeddingModel(abc.ABC):
 
         dataset_handle.set_data(X_pos, "pos")
 
-        batch_size_pos = int(np.ceil(dataset_handle.get_size("pos") / batches_count))
-
-        gen_fn = partial(dataset_handle.get_next_train_batch, batch_size=batch_size_pos, dataset_type="pos")
+        gen_fn = partial(dataset_handle.get_next_train_batch, batches_count=batches_count, dataset_type="pos")
         dataset = tf.data.Dataset.from_generator(gen_fn,
                                                  output_types=tf.int32,
                                                  output_shapes=(None, 3))

--- a/tests/ampligraph/latent_features/test_models.py
+++ b/tests/ampligraph/latent_features/test_models.py
@@ -398,3 +398,4 @@ def test_calibrate_with_negatives():
     probas = model.predict_proba(np.concatenate((X_pos, X_neg)))
 
     assert np.logical_and(probas > 0, probas < 1).all()
+


### PR DESCRIPTION
#### Related Issue(s)
#135 

#### Description of Changes
Instead of calculating batches count on the fly based on the batch size, which leads to discrepancies (see bug report above), now it calculates the batch size based on the batch count, making sure the same batch count will be used in the inner and outer loops.

#### Any other comments?
Should I make any changes to large graph mode @sumitpai ?
