### PR TITLE
Fixed bug where self.ent_emb was not reinitialized when loading model…

### DIFF
--- a/ampligraph/latent_features/models/ConvKB.py
+++ b/ampligraph/latent_features/models/ConvKB.py
@@ -284,6 +284,7 @@ class ConvKB(EmbeddingModel):
             self.ent_emb = tf.Variable(self.trained_model_params['ent_emb'], dtype=tf.float32)
         else:
             self.ent_emb_cpu = self.trained_model_params['ent_emb']
+            self.ent_emb = tf.Variable(np.zeros((self.batch_size, self.internal_k)), dtype=tf.float32)
 
         self.rel_emb = tf.Variable(self.trained_model_params['rel_emb'], dtype=tf.float32)
 


### PR DESCRIPTION
Issue: The self.ent_emb tf.Variable was not reinitialized when loading ConvKB model weights in large graph mode. 

Fix: Initialized self.ent_emb in same manner as in EmbeddingModel. 



