### PR TITLE
Feature/210

### DIFF
--- a/ampligraph/evaluation/protocol.py
+++ b/ampligraph/evaluation/protocol.py
@@ -675,7 +675,7 @@ def check_filter_size(model, corruption_entities):
 
     """
 
-    warn_msg = """You are attempting to use %d distinct entities to generate synthetic negatives in the evaluation 
+    warn_msg = """You are attempting to use %d distinct entities to generate synthetic negatives in the evaluation
     protocol. This may be unnecessary and will lead to a 'harder' task. Besides, it will lead to a much slower
     evaluation procedure. We recommended to set the 'corruption_entities' argument to a reasonably sized set
     of entities. The size of corruption_entities depends on your domain-specific task."""

--- a/ampligraph/latent_features/initializers.py
+++ b/ampligraph/latent_features/initializers.py
@@ -84,7 +84,7 @@ class Initializer(abc.ABC):
 
     def _get_tf_initializer(self, in_shape=None, out_shape=None, concept='e'):
         """Create a tensorflow node for initializer
-        
+
         Parameters
         ----------
         in_shape: int
@@ -118,10 +118,10 @@ class Initializer(abc.ABC):
             Initialized weights
         """
         raise NotImplementedError('Abstract Method not implemented!')
-        
+
     def get_entity_initializer(self, in_shape=None, out_shape=None, init_type='tf'):
         """ Initializer for entity embeddings
-        
+
         Parameters
         ----------
         in_shape: int
@@ -141,10 +141,10 @@ class Initializer(abc.ABC):
             return self._get_tf_initializer(in_shape, out_shape, 'e')
         else:
             return self._get_np_initializer(in_shape, out_shape, 'e')
-    
+
     def get_relation_initializer(self, in_shape=None, out_shape=None, init_type='tf'):
         """ Initializer for relation embeddings
-        
+
         Parameters
         ----------
         in_shape: int
@@ -216,7 +216,7 @@ class RandomNormal(Initializer):
 
     def _get_tf_initializer(self, in_shape=None, out_shape=None, concept='e'):
         """Create a tensorflow node for initializer
-        
+
         Parameters
         ----------
         in_shape: int
@@ -306,7 +306,7 @@ class RandomUniform(Initializer):
 
     def _get_tf_initializer(self, in_shape=None, out_shape=None, concept='e'):
         """Create a tensorflow node for initializer
-        
+
         Parameters
         ----------
         in_shape: int
@@ -404,7 +404,7 @@ class Xavier(Initializer):
 
     def _get_tf_initializer(self, in_shape=None, out_shape=None, concept='e'):
         """Create a tensorflow node for initializer
-        
+
         Parameters
         ----------
         in_shape: int
@@ -495,7 +495,7 @@ class Constant(Initializer):
 
     def _get_tf_initializer(self, in_shape=None, out_shape=None, concept='e'):
         """Create a tensorflow node for initializer
-        
+
         Parameters
         ----------
         in_shape: int
@@ -509,20 +509,20 @@ class Constant(Initializer):
         -------
         initializer_instance: An Initializer instance.
         """
-        
+
         if concept == 'e':
             assert self._initializer_params['entity'].shape[0] == in_shape and \
                 self._initializer_params['entity'].shape[1] == out_shape, \
                 "Invalid shape for entity initializer!"
-        
+
             return tf.compat.v1.constant_initializer(self._initializer_params['entity'], dtype=tf.float32)
         else:
             assert self._initializer_params['relation'].shape[0] == in_shape and \
                 self._initializer_params['relation'].shape[1] == out_shape, \
                 "Invalid shape for relation initializer!"
-        
+
             return tf.compat.v1.constant_initializer(self._initializer_params['relation'], dtype=tf.float32)
-        
+
     def _get_np_initializer(self, in_shape, out_shape, concept='e'):
         """Create an initialized numpy array
 
@@ -544,11 +544,11 @@ class Constant(Initializer):
             assert self._initializer_params['entity'].shape[0] == in_shape and \
                 self._initializer_params['entity'].shape[1] == out_shape, \
                 "Invalid shape for entity initializer!"
-        
+
             return self._initializer_params['entity']
         else:
             assert self._initializer_params['relation'].shape[0] == in_shape and \
                 self._initializer_params['relation'].shape[1] == out_shape, \
                 "Invalid shape for relation initializer!"
-        
+
             return self._initializer_params['relation']

--- a/ampligraph/latent_features/models/ConvE.py
+++ b/ampligraph/latent_features/models/ConvE.py
@@ -989,6 +989,10 @@ class ConvE(EmbeddingModel):
         self.rnd = check_random_state(self.seed)
         tf.random.set_random_seed(self.seed)
         self._load_model_from_trained_params()
+
+        # Set the output mapping of the dataset handle - this is superceded if a filter has been set.
+        dataset_handle.set_output_mapping(self.output_mapping)
+
         self._initialize_eval_graph()
 
         with tf.Session(config=self.tf_config) as sess:
@@ -1069,6 +1073,10 @@ class ConvE(EmbeddingModel):
         self.rnd = check_random_state(self.seed)
         tf.random.set_random_seed(self.seed)
         self._load_model_from_trained_params()
+
+        # Set the output mapping of the dataset handle - this is superceded if a filter has been set.
+        dataset_handle.set_output_mapping(self.output_mapping)
+
         self._initialize_eval_graph_subject()
 
         if not corruption_batch_size:

--- a/ampligraph/latent_features/models/EmbeddingModel.py
+++ b/ampligraph/latent_features/models/EmbeddingModel.py
@@ -906,7 +906,7 @@ class EmbeddingModel(abc.ABC):
             if self.dealing_with_large_graphs:
                 prefetch_batches = 0
                 # CPU matrix of embeddings
-                self.ent_emb_cpu = self.initializer.get_entity_initializer(len(self.ent_to_idx), 
+                self.ent_emb_cpu = self.initializer.get_entity_initializer(len(self.ent_to_idx),
                                                                            self.internal_k,
                                                                            'np')
 


### PR DESCRIPTION
Fixed ConvE model not working with evaluate_protocol if the filter_triples are not set. 

The saved/restored output_mapping was not being set in the dataset handle. This is now the default behaviour, and an alternative output mapping can only be used by setting the filter_triples. 
