### PR TITLE
Feature/230

### DIFF
--- a/ampligraph/latent_features/models/ComplEx.py
+++ b/ampligraph/latent_features/models/ComplEx.py
@@ -255,7 +255,7 @@ class ComplEx(EmbeddingModel):
             tf.reduce_sum(e_p_img * e_s_real * e_o_img, axis=1) - \
             tf.reduce_sum(e_p_img * e_s_img * e_o_real, axis=1)
 
-    def fit(self, X, early_stopping=False, early_stopping_params={}, focusE_numeric_edge_values=None):
+    def fit(self, X, early_stopping=False, early_stopping_params={}, focusE_numeric_edge_values=None, tensorboard=False):
         """Train a ComplEx model.
 
         The model is trained on a training set X using the training protocol
@@ -321,7 +321,7 @@ class ComplEx(EmbeddingModel):
             One can also think about assigning numeric values by looking at the distribution of it per predicate.
             
         """
-        super().fit(X, early_stopping, early_stopping_params, focusE_numeric_edge_values)
+        super().fit(X, early_stopping, early_stopping_params, focusE_numeric_edge_values, tensorboard=tensorboard)
 
     def predict(self, X, from_idx=False):
         __doc__ = super().predict.__doc__  # NOQA

--- a/ampligraph/latent_features/models/ComplEx.py
+++ b/ampligraph/latent_features/models/ComplEx.py
@@ -255,7 +255,7 @@ class ComplEx(EmbeddingModel):
             tf.reduce_sum(e_p_img * e_s_real * e_o_img, axis=1) - \
             tf.reduce_sum(e_p_img * e_s_img * e_o_real, axis=1)
 
-    def fit(self, X, early_stopping=False, early_stopping_params={}, focusE_numeric_edge_values=None, tensorboard=False):
+    def fit(self, X, early_stopping=False, early_stopping_params={}, focusE_numeric_edge_values=None, tensorboard_logs_path=None):
         """Train a ComplEx model.
 
         The model is trained on a training set X using the training protocol
@@ -321,7 +321,7 @@ class ComplEx(EmbeddingModel):
             One can also think about assigning numeric values by looking at the distribution of it per predicate.
             
         """
-        super().fit(X, early_stopping, early_stopping_params, focusE_numeric_edge_values, tensorboard=tensorboard)
+        super().fit(X, early_stopping, early_stopping_params, focusE_numeric_edge_values, tensorboard_logs_path=tensorboard_logs_path)
 
     def predict(self, X, from_idx=False):
         __doc__ = super().predict.__doc__  # NOQA

--- a/ampligraph/latent_features/models/ConvKB.py
+++ b/ampligraph/latent_features/models/ConvKB.py
@@ -418,7 +418,7 @@ class ConvKB(EmbeddingModel):
 
         return tf.squeeze(self.scores)
 
-    def fit(self, X, early_stopping=False, early_stopping_params={}, focusE_numeric_edge_values=None):
+    def fit(self, X, early_stopping=False, early_stopping_params={}, focusE_numeric_edge_values=None, tensorboard=False):
         """Train a ConvKB model (with optional early stopping).
 
         The model is trained on a training set X using the training protocol described in :cite:`trouillon2016complex`.
@@ -493,4 +493,4 @@ class ConvKB(EmbeddingModel):
             One can also think about assigning numeric values by looking at the distribution of it per predicate.
             
         """
-        super().fit(X, early_stopping, early_stopping_params, focusE_numeric_edge_values)
+        super().fit(X, early_stopping, early_stopping_params, focusE_numeric_edge_values, tensorboard=tensorboard)

--- a/ampligraph/latent_features/models/ConvKB.py
+++ b/ampligraph/latent_features/models/ConvKB.py
@@ -418,7 +418,7 @@ class ConvKB(EmbeddingModel):
 
         return tf.squeeze(self.scores)
 
-    def fit(self, X, early_stopping=False, early_stopping_params={}, focusE_numeric_edge_values=None, tensorboard=False):
+    def fit(self, X, early_stopping=False, early_stopping_params={}, focusE_numeric_edge_values=None, tensorboard_logs_path=None):
         """Train a ConvKB model (with optional early stopping).
 
         The model is trained on a training set X using the training protocol described in :cite:`trouillon2016complex`.
@@ -493,4 +493,4 @@ class ConvKB(EmbeddingModel):
             One can also think about assigning numeric values by looking at the distribution of it per predicate.
             
         """
-        super().fit(X, early_stopping, early_stopping_params, focusE_numeric_edge_values, tensorboard=tensorboard)
+        super().fit(X, early_stopping, early_stopping_params, focusE_numeric_edge_values, tensorboard_logs_path=tensorboard_logs_path)

--- a/ampligraph/latent_features/models/DistMult.py
+++ b/ampligraph/latent_features/models/DistMult.py
@@ -201,7 +201,7 @@ class DistMult(EmbeddingModel):
 
         return tf.reduce_sum(e_s * e_p * e_o, axis=1)
 
-    def fit(self, X, early_stopping=False, early_stopping_params={}, focusE_numeric_edge_values=None, tensorboard=False):
+    def fit(self, X, early_stopping=False, early_stopping_params={}, focusE_numeric_edge_values=None, tensorboard_logs_path=None):
         """Train an DistMult.
 
         The model is trained on a training set X using the training protocol
@@ -267,7 +267,7 @@ class DistMult(EmbeddingModel):
             One can also think about assigning numeric values by looking at the distribution of it per predicate.
             
         """
-        super().fit(X, early_stopping, early_stopping_params, focusE_numeric_edge_values, tensorboard=tensorboard)
+        super().fit(X, early_stopping, early_stopping_params, focusE_numeric_edge_values, tensorboard_logs_path=tensorboard_logs_path)
 
     def predict(self, X, from_idx=False):
         __doc__ = super().predict.__doc__  # NOQA

--- a/ampligraph/latent_features/models/DistMult.py
+++ b/ampligraph/latent_features/models/DistMult.py
@@ -201,7 +201,7 @@ class DistMult(EmbeddingModel):
 
         return tf.reduce_sum(e_s * e_p * e_o, axis=1)
 
-    def fit(self, X, early_stopping=False, early_stopping_params={}, focusE_numeric_edge_values=None):
+    def fit(self, X, early_stopping=False, early_stopping_params={}, focusE_numeric_edge_values=None, tensorboard=False):
         """Train an DistMult.
 
         The model is trained on a training set X using the training protocol
@@ -267,7 +267,7 @@ class DistMult(EmbeddingModel):
             One can also think about assigning numeric values by looking at the distribution of it per predicate.
             
         """
-        super().fit(X, early_stopping, early_stopping_params, focusE_numeric_edge_values)
+        super().fit(X, early_stopping, early_stopping_params, focusE_numeric_edge_values, tensorboard=tensorboard)
 
     def predict(self, X, from_idx=False):
         __doc__ = super().predict.__doc__  # NOQA

--- a/ampligraph/latent_features/models/EmbeddingModel.py
+++ b/ampligraph/latent_features/models/EmbeddingModel.py
@@ -828,9 +828,9 @@ class EmbeddingModel(abc.ABC):
                 current_test_value = hits_at_n_score(ranks, 1)
             elif self.early_stopping_criteria == 'mrr':
                 current_test_value = mrr_score(ranks)
-
-            summary = tf.Summary(value=[tf.Summary.Value(tag="Early stopping {} current value".format(self.early_stopping_criteria), 
-                                                                                                      simple_value=current_test_value)])
+            tag = "Early stopping {} current value".format(self.early_stopping_criteria)
+            summary = tf.Summary(value=[tf.Summary.Value(tag=tag, 
+                                                         simple_value=current_test_value)])
             self.writer.add_summary(summary, epoch)
 
             if self.early_stopping_best_value is None:  # First validation iteration
@@ -1157,7 +1157,9 @@ class EmbeddingModel(abc.ABC):
                     if self.embedding_model_params.get('normalize_ent_emb', constants.DEFAULT_NORMALIZE_EMBEDDINGS):
                         self.sess_train.run(normalize_ent_emb_op)
                 if tensorboard_logs_path is not None:
-                    summary = tf.Summary(value=[tf.Summary.Value(tag="Average Loss", simple_value=sum(losses)/(batch_size * self.batches_count))])
+                    avg_loss = sum(losses)/(batch_size * self.batches_count)
+                    summary = tf.Summary(value=[tf.Summary.Value(tag="Average Loss",
+                                                                     simple_value=avg_loss)])
                     self.writer.add_summary(summary, epoch)
                 if self.verbose:
                     focusE = ''

--- a/ampligraph/latent_features/models/EmbeddingModel.py
+++ b/ampligraph/latent_features/models/EmbeddingModel.py
@@ -983,6 +983,11 @@ class EmbeddingModel(abc.ABC):
             If the numeric value is unknown pass a NaN weight. The model will uniformly randomly assign a numeric value.
             One can also think about assigning numeric values by looking at the distribution of it per predicate.
 
+        tensorboard: bool
+            Flag to enable average training loss tracking per epoch via tensorboard (default: ``False``). When enabled
+            it will create a ``tensorboard_files`` folder within current directory and save tensorboard files there.
+            To then view the loss in the terminal run: ``tensorboard --logdir ./tensorboard_files``.
+
         """
         self.train_dataset_handle = None
         # try-except block is mainly to handle clean up in case of exception or manual stop in jupyter notebook

--- a/ampligraph/latent_features/models/HolE.py
+++ b/ampligraph/latent_features/models/HolE.py
@@ -183,7 +183,7 @@ class HolE(ComplEx):
         """
         return (2 / self.k) * (super()._fn(e_s, e_p, e_o))
 
-    def fit(self, X, early_stopping=False, early_stopping_params={}, focusE_numeric_edge_values=None, tensorboard=False):
+    def fit(self, X, early_stopping=False, early_stopping_params={}, focusE_numeric_edge_values=None, tensorboard_logs_path=None):
         """Train a HolE model.
 
         The model is trained on a training set X using the training protocol
@@ -249,7 +249,7 @@ class HolE(ComplEx):
             One can also think about assigning numeric values by looking at the distribution of it per predicate.
             
         """
-        super().fit(X, early_stopping, early_stopping_params, focusE_numeric_edge_values, tensorboard=tensorboard)
+        super().fit(X, early_stopping, early_stopping_params, focusE_numeric_edge_values, tensorboard_logs_path=tensorboard_logs_path)
 
     def predict(self, X, from_idx=False):
         __doc__ = super().predict.__doc__  # NOQA

--- a/ampligraph/latent_features/models/HolE.py
+++ b/ampligraph/latent_features/models/HolE.py
@@ -183,7 +183,7 @@ class HolE(ComplEx):
         """
         return (2 / self.k) * (super()._fn(e_s, e_p, e_o))
 
-    def fit(self, X, early_stopping=False, early_stopping_params={}, focusE_numeric_edge_values=None):
+    def fit(self, X, early_stopping=False, early_stopping_params={}, focusE_numeric_edge_values=None, tensorboard=False):
         """Train a HolE model.
 
         The model is trained on a training set X using the training protocol
@@ -249,7 +249,7 @@ class HolE(ComplEx):
             One can also think about assigning numeric values by looking at the distribution of it per predicate.
             
         """
-        super().fit(X, early_stopping, early_stopping_params, focusE_numeric_edge_values)
+        super().fit(X, early_stopping, early_stopping_params, focusE_numeric_edge_values, tensorboard=tensorboard)
 
     def predict(self, X, from_idx=False):
         __doc__ = super().predict.__doc__  # NOQA

--- a/ampligraph/latent_features/models/RandomBaseline.py
+++ b/ampligraph/latent_features/models/RandomBaseline.py
@@ -79,7 +79,7 @@ class RandomBaseline(EmbeddingModel):
         else:
             return tf.random_uniform((tf.size(e_s),), minval=0, maxval=1)
 
-    def fit(self, X, early_stopping=False, early_stopping_params={}, focusE_numeric_edge_values=None):
+    def fit(self, X, early_stopping=False, early_stopping_params={}, focusE_numeric_edge_values=None, tensorboard=False):
         """Train the random model.
 
         There is no actual training involved in practice and the early stopping parameters won't have any effect.
@@ -143,7 +143,7 @@ class RandomBaseline(EmbeddingModel):
             If the numeric value is unknown pass a NaN weight. The model will uniformly randomly assign a numeric value.
             One can also think about assigning numeric values by looking at the distribution of it per predicate.
         """
-        super().fit(X, early_stopping, early_stopping_params, focusE_numeric_edge_values)
+        super().fit(X, early_stopping, early_stopping_params, focusE_numeric_edge_values, tensorboard=tensorboard)
 
     def predict(self, X, from_idx=False):
         __doc__ = super().predict.__doc__  # NOQA

--- a/ampligraph/latent_features/models/RandomBaseline.py
+++ b/ampligraph/latent_features/models/RandomBaseline.py
@@ -79,7 +79,7 @@ class RandomBaseline(EmbeddingModel):
         else:
             return tf.random_uniform((tf.size(e_s),), minval=0, maxval=1)
 
-    def fit(self, X, early_stopping=False, early_stopping_params={}, focusE_numeric_edge_values=None, tensorboard=False):
+    def fit(self, X, early_stopping=False, early_stopping_params={}, focusE_numeric_edge_values=None, tensorboard_logs_path=None):
         """Train the random model.
 
         There is no actual training involved in practice and the early stopping parameters won't have any effect.
@@ -143,7 +143,7 @@ class RandomBaseline(EmbeddingModel):
             If the numeric value is unknown pass a NaN weight. The model will uniformly randomly assign a numeric value.
             One can also think about assigning numeric values by looking at the distribution of it per predicate.
         """
-        super().fit(X, early_stopping, early_stopping_params, focusE_numeric_edge_values, tensorboard=tensorboard)
+        super().fit(X, early_stopping, early_stopping_params, focusE_numeric_edge_values, tensorboard_logs_path=tensorboard_logs_path)
 
     def predict(self, X, from_idx=False):
         __doc__ = super().predict.__doc__  # NOQA

--- a/ampligraph/latent_features/models/TransE.py
+++ b/ampligraph/latent_features/models/TransE.py
@@ -209,7 +209,7 @@ class TransE(EmbeddingModel):
             tf.norm(e_s + e_p - e_o, ord=self.embedding_model_params.get('norm', constants.DEFAULT_NORM_TRANSE),
                     axis=1))
 
-    def fit(self, X, early_stopping=False, early_stopping_params={}, focusE_numeric_edge_values=None, tensorboard=False):
+    def fit(self, X, early_stopping=False, early_stopping_params={}, focusE_numeric_edge_values=None, tensorboard_logs_path=None):
         """Train an Translating Embeddings model.
 
         The model is trained on a training set X using the training protocol
@@ -275,7 +275,7 @@ class TransE(EmbeddingModel):
             One can also think about assigning numeric values by looking at the distribution of it per predicate.
             
         """
-        super().fit(X, early_stopping, early_stopping_params, focusE_numeric_edge_values, tensorboard=tensorboard)
+        super().fit(X, early_stopping, early_stopping_params, focusE_numeric_edge_values, tensorboard_logs_path=tensorboard_logs_path)
 
     def predict(self, X, from_idx=False):
         __doc__ = super().predict.__doc__  # NOQA

--- a/ampligraph/latent_features/models/TransE.py
+++ b/ampligraph/latent_features/models/TransE.py
@@ -209,7 +209,7 @@ class TransE(EmbeddingModel):
             tf.norm(e_s + e_p - e_o, ord=self.embedding_model_params.get('norm', constants.DEFAULT_NORM_TRANSE),
                     axis=1))
 
-    def fit(self, X, early_stopping=False, early_stopping_params={}, focusE_numeric_edge_values=None):
+    def fit(self, X, early_stopping=False, early_stopping_params={}, focusE_numeric_edge_values=None, tensorboard=False):
         """Train an Translating Embeddings model.
 
         The model is trained on a training set X using the training protocol
@@ -275,7 +275,7 @@ class TransE(EmbeddingModel):
             One can also think about assigning numeric values by looking at the distribution of it per predicate.
             
         """
-        super().fit(X, early_stopping, early_stopping_params, focusE_numeric_edge_values)
+        super().fit(X, early_stopping, early_stopping_params, focusE_numeric_edge_values, tensorboard=tensorboard)
 
     def predict(self, X, from_idx=False):
         __doc__ = super().predict.__doc__  # NOQA


### PR DESCRIPTION
<!--
Thanks for contributing to AmpliGraph. How to Contribute guidelines available here at http://docs.ampligraph.org/en/latest/dev.html
-->

#### Related Issue(s)
<!--
Example: Fixes #555. See also #666.
-->
Issue #230 
#### Description of Changes

Added parameter `tensorboard=False` to model fit function (EmbeddingModel derivatives) to visualize average training loss after each epoch with tensorboard.
After model is trained with e.g. CompleX(...,tensorboard=True), tensorboard_files folder is created where loss is being logged. To see the loss, run: 
`tensorboard --logdir tensorboard_files/`
and go to your browser to see the loss plotted. 
#### Any other comments?

