### PR TITLE
Fixing flaky test

### DIFF
--- a/tests/ampligraph/evaluation/test_protocol.py
+++ b/tests/ampligraph/evaluation/test_protocol.py
@@ -1079,7 +1079,7 @@ def test_select_best_model_ranking_random():
     assert best_params['k'] in (2, 50)
     assert np.log(1.00001) <= best_params['optimizer_params']['lr'] <= np.log(100)
     assert len(experimental_history) == 10
-    assert set(i["model_params"]["k"] for i in experimental_history) == {2, 50}
+    assert all(i["model_params"]["k"] in [2, 50] for i in experimental_history)
     assert np.all([np.log(1.00001) <= i["model_params"]["optimizer_params"]["lr"] <= np.log(100)
                    for i in experimental_history])
     assert len(set(frozenset(_flatten_nested_keys(i["model_params"]).items()) for i in experimental_history)) == 10


### PR DESCRIPTION
I ran your test-suite by removing all seed settings (such as `np.random_seed(0)`) and found that some tests fail quite often. For instance, the test `test_select_best_model_ranking_random` failed 3 out of 500 times. Each time the same assertion failed. 

To fix the test, I modified the assertion to ensure that it does not fail if the seeds are removed (or if the seed/rng implementation is changed in the future). The test does not fail now at all without seeds.

Please let me know if this fix seems reasonable. If yes, I can also look into other tests which failed and try to make them less flaky. I will be happy to incorporate any other changes that you guys may suggest.

Thanks!