### PR TITLE
Add timeout to requests calls

### DIFF
--- a/ampligraph/compat/models.py
+++ b/ampligraph/compat/models.py
@@ -295,13 +295,11 @@ class ScoringModelBase:
             )
             callbacks.append(tensorboard_callback)
 
-        regularizer = self.regularizer
-        if regularizer is not None:
+        if (regularizer := self.regularizer) is not None:
             regularizer = get_regularizer(regularizer,
                                           self.regularizer_params)
 
-        initializer = self.initializer
-        if initializer is not None:
+        if (initializer := self.initializer) is not None:
             initializer = self._get_initializer(
                 initializer, self.initializer_params
             )

--- a/ampligraph/datasets/datasets.py
+++ b/ampligraph/datasets/datasets.py
@@ -1874,7 +1874,7 @@ def _load_xai_fb15k_237_experiment_log(full=False, subset="all"):
 
     url = "https://ampgraphenc.s3-eu-west-1.amazonaws.com/datasets/xai_fb15k_237.csv"
 
-    r = requests.get(url, allow_redirects=True)
+    r = requests.get(url, allow_redirects=True, timeout=60)
     open("xai_fb15k_237.csv", "wb").write(r.content)
 
     mapper = {

--- a/ampligraph/datasets/graph_partitioner.py
+++ b/ampligraph/datasets/graph_partitioner.py
@@ -358,10 +358,9 @@ class BucketGraphPartitioner(AbstractGraphPartitioner):
             # condition that excludes duplicated partitions
             # from k x k possibilities, partition 0-1 and 1-0 is the same - not
             # needed
-            status_not_ok = self.create_single_partition(
+            if status_not_ok := self.create_single_partition(
                 i, i, timestamp, partition_nb, batch_size=batch_size
-            )
-            if status_not_ok:
+            ):
                 continue
             partition_nb += 1
 

--- a/ampligraph/datasets/sqlite_adapter.py
+++ b/ampligraph/datasets/sqlite_adapter.py
@@ -584,8 +584,7 @@ class SQLiteAdapter:
 
         """
         query = "SELECT count(*) from {} {};".format(table, condition)
-        count = self._execute_query(query)
-        if count is None:
+        if (count := self._execute_query(query)) is None:
             logger.debug("Table is empty or not such table exists.")
             return count
         elif not isinstance(count, list) or not isinstance(count[0], tuple):
@@ -804,9 +803,8 @@ class SQLiteAdapter:
                 dataset_type, index, i * batch_size, batch_size
             )
             # logger.debug(query)
-            out = self._execute_query(query)
             # logger.debug(out)
-            if out:
+            if out := self._execute_query(query):
                 triples = np.array(out)[:, :3].astype(np.int32)
                 # focusE
                 if self.data_shape > 3:

--- a/ampligraph/latent_features/models/ScoringBasedEmbeddingModel.py
+++ b/ampligraph/latent_features/models/ScoringBasedEmbeddingModel.py
@@ -497,8 +497,7 @@ class ScoringBasedEmbeddingModel(tf.keras.Model):
 
         """
         # Get the non-linearity function
-        non_linearity = dict_params.get("non_linearity", "linear")
-        if non_linearity == "linear":
+        if (non_linearity := dict_params.get("non_linearity", "linear")) == "linear":
             non_linearity = tf.identity
         elif non_linearity == "tanh":
             non_linearity = tf.tanh

--- a/ampligraph/utils/model_utils.py
+++ b/ampligraph/utils/model_utils.py
@@ -380,8 +380,7 @@ def preprocess_focusE_weights(data, weights, normalize=True):
     for reln in unique_relations:
         for col_idx in range(weights.shape[1]):
             # here nans signify unknown numeric values
-            suma = np.sum(pd.isna(weights[data[:, 1] == reln, col_idx]))
-            if suma != weights[data[:, 1] == reln, col_idx].shape[0]:
+            if (suma := np.sum(pd.isna(weights[data[:, 1] == reln, col_idx]))) != weights[data[:, 1] == reln, col_idx].shape[0]:
                 min_val = np.nanmin(
                     weights[data[:, 1] == reln, col_idx].astype(np.float32)
                 )

--- a/experiments/predictive_performance.py
+++ b/experiments/predictive_performance.py
@@ -113,8 +113,7 @@ def run_single_exp(config, dataset, model, root=None):
     start_time = time.time()
     print("Started: ",start_time)
 
-    hyperparams = config["hyperparams"][dataset][model]
-    if hyperparams is None:
+    if (hyperparams := config["hyperparams"][dataset][model]) is None:
         print("dataset {0}...model {1} \
                       experiment is not conducted yet..." \
                      .format(dataset, config["model_name_map"][model]))


### PR DESCRIPTION
Many developers will be surprised to learn that `requests` library calls do not include timeouts by default. This means that an attempted request could hang indefinitely if no connection is established or if no data is received from the server. 

The [requests documentation](https://requests.readthedocs.io/en/latest/user/advanced/#timeouts) suggests that most calls should explicitly include a `timeout` parameter. This codemod adds a default timeout value in order to set an upper bound on connection times and ensure that requests connect or fail in a timely manner. This value also ensures the connection will timeout if the server does not respond with data within a reasonable amount of time. 

While timeout values will be application dependent, we believe that this codemod adds a reasonable default that serves as an appropriate ceiling for most situations. 

Our changes look like the following:
```diff
 import requests
 
- requests.get("http://example.com")
+ requests.get("http://example.com", timeout=60)
```

<details>
  <summary>More reading</summary>

  * [https://docs.python-requests.org/en/master/user/quickstart/#timeouts](https://docs.python-requests.org/en/master/user/quickstart/#timeouts)
</details>

I have additional improvements ready for this repo! If you want to see them, leave the comment:
```
@pixeebot next
```
... and I will open a new PR right away!

Powered by: [pixeebot](https://docs.pixee.ai/) (codemod ID: [pixee:python/add-requests-timeouts](https://docs.pixee.ai/codemods/python/pixee_python_add-requests-timeouts)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7Ccitizenjosh%2FAmpliGraph%7Ce56c1b15e8fd2127484be7cf0f3dba301a84b4ce)

<!--{"type":"DRIP","codemod":"pixee:python/add-requests-timeouts"}-->