### PR TITLE
Sandbox URL Creation

### DIFF
--- a/ampligraph/datasets/datasets.py
+++ b/ampligraph/datasets/datasets.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
+from security import safe_requests
 
 AMPLIGRAPH_ENV_NAME = "AMPLIGRAPH_DATA_HOME"
 
@@ -1870,11 +1871,10 @@ def _load_xai_fb15k_237_experiment_log(full=False, subset="all"):
     1 	/film/film/edited_by 	                Edited by 	        NaN 	                                        /m/0cc5qkt 	War Horse 	Michael Kahn 	/m/03q8ch
 
     """
-    import requests
 
     url = "https://ampgraphenc.s3-eu-west-1.amazonaws.com/datasets/xai_fb15k_237.csv"
 
-    r = requests.get(url, allow_redirects=True)
+    r = safe_requests.get(url, allow_redirects=True)
     open("xai_fb15k_237.csv", "wb").write(r.content)
 
     mapper = {


### PR DESCRIPTION
This codemod sandboxes calls to [`requests.get`](https://requests.readthedocs.io/en/latest/api/#requests.get) to be more resistant to Server-Side Request Forgery (SSRF) attacks.

Most of the time when you make a `GET` request to a URL, you're intending to reference an HTTP endpoint, like an internal microservice. However, URLs can point to local file system files, a Gopher stream in your local network, a JAR file on a remote Internet site, and all kinds of other unexpected and undesirable outcomes. When the URL values are influenced by attackers, they can trick your application into fetching internal resources, running malicious code, or otherwise harming the system.
Consider the following code for a Flask app:

```python
from flask import Flask, request
import requests

app = Flask(__name__)

@app.route("/request-url")
def request_url():
    url = request.args["loc"]
    resp = requests.get(url)
    ...
```

In this case, an attacker could supply a value like `"http://169.254.169.254/user-data/"` and attempt to access user information.

Our changes introduce sandboxing around URL creation that force developers to specify some boundaries on the types of URLs they expect to create:

```diff
  from flask import Flask, request
- import requests
+ from security import safe_requests

  app = Flask(__name__)

  @app.route("/request-url")
  def request_url():
    url = request.args["loc"]
-   resp = requests.get(url)
+   resp = safe_requests.get.get(url)
    ...
```

This change alone reduces attack surface significantly because the default behavior of `safe_requests.get` raises a `SecurityException` if
a user attempts to access a known infrastructure location, unless specifically disabled.


If you have feedback on this codemod, [please let us know](mailto:feedback@pixee.ai)!

## F.A.Q. 

### Why does this codemod require a Pixee dependency?

We always prefer to use built-in Python functions or one from a well-known and trusted community dependency. However, we cannot find any such control. If you know of one, [please let us know](https://ask.pixee.ai/feedback).

### Why is this codemod marked as Merge After Cursory Review?

By default, the protection only weaves in 2 checks, which we believe will not cause any issues with the vast majority of code:
1. The given URL must be HTTP/HTTPS.
2. The given URL must not point to a "well-known infrastructure target", which includes things like AWS Metadata Service endpoints, and internal routers (e.g., 192.168.1.1) which are common targets of attacks.

However, on rare occasions an application may use a URL protocol like "file://" or "ftp://" in backend or middleware code.

If you want to allow those protocols, change the incoming PR to look more like this and get the best security possible:

```diff
-resp = requests.get(url)
+resp = safe_requests.get.get(url, allowed_protocols=("ftp",))
```


```
💡 This codemod adds a dependency to your project. Currently we add the dependency to a file named `requirements.txt` if it exists in your project.

There are a number of other places where Python project dependencies can be expressed, including `setup.py`, `pyproject.toml`, and `setup.cfg`. We are working on adding support for these files, but for now you may need to update these files manually before accepting this change.
```

<details>
  <summary>More reading</summary>

  * [https://github.com/pixee/python-security/blob/main/src/security/safe_requests/api.py](https://github.com/pixee/python-security/blob/main/src/security/safe_requests/api.py)
  * [https://portswigger.net/web-security/ssrf](https://portswigger.net/web-security/ssrf)
  * [https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html](https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html)
  * [https://www.rapid7.com/blog/post/2021/11/23/owasp-top-10-deep-dive-defending-against-server-side-request-forgery/](https://www.rapid7.com/blog/post/2021/11/23/owasp-top-10-deep-dive-defending-against-server-side-request-forgery/)
  * [https://blog.assetnote.io/2021/01/13/blind-ssrf-chains/](https://blog.assetnote.io/2021/01/13/blind-ssrf-chains/)
</details>

I have additional improvements ready for this repo! If you want to see them, leave the comment:
```
@pixeebot next
```
... and I will open a new PR right away!

Powered by: [pixeebot](https://docs.pixee.ai/) (codemod ID: [pixee:python/url-sandbox](https://docs.pixee.ai/codemods/python/pixee_python_url-sandbox)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7Ccitizenjosh%2FAmpliGraph%7Caad0116441b81323934e320fb46cefa1b46e7803)

<!--{"type":"DRIP","codemod":"pixee:python/url-sandbox"}-->