### PR TITLE
Replace Mutable Default Parameters

### DIFF
--- a/ampligraph/compat/models.py
+++ b/ampligraph/compat/models.py
@@ -34,20 +34,15 @@ class ScoringModelBase:
         epochs=100,
         batches_count=100,
         seed=0,
-        embedding_model_params={
-            "corrupt_sides": ["s,o"],
-            "negative_corruption_entities": "all",
-            "norm": 1,
-            "normalize_ent_emb": False,
-        },
+        embedding_model_params=None,
         optimizer="adam",
-        optimizer_params={"lr": 0.0005},
+        optimizer_params=None,
         loss="nll",
-        loss_params={},
+        loss_params=None,
         regularizer=None,
-        regularizer_params={},
+        regularizer_params=None,
         initializer="xavier",
-        initializer_params={"uniform": False},
+        initializer_params=None,
         verbose=False,
         model=None,
     ):
@@ -126,6 +121,16 @@ class ScoringModelBase:
         verbose : bool
             Verbose mode.
         """
+        embedding_model_params = {
+                "corrupt_sides": ["s,o"],
+                "negative_corruption_entities": "all",
+                "norm": 1,
+                "normalize_ent_emb": False,
+            } if embedding_model_params is None else embedding_model_params
+        optimizer_params = {"lr": 0.0005} if optimizer_params is None else optimizer_params
+        loss_params = {} if loss_params is None else loss_params
+        regularizer_params = {} if regularizer_params is None else regularizer_params
+        initializer_params = {"uniform": False} if initializer_params is None else initializer_params
         if model is not None:
             self.model_name = model.scoring_type
         else:
@@ -220,7 +225,7 @@ class ScoringModelBase:
         self,
         X,
         early_stopping=False,
-        early_stopping_params={},
+        early_stopping_params=None,
         focusE_numeric_edge_values=None,
         tensorboard_logs_path=None,
         callbacks=None,
@@ -284,6 +289,7 @@ class ScoringModelBase:
             path and save tensorboard files there. To then view the loss in
             the terminal run: ``tensorboard --logdir <tensorboard_logs_path>``.
         """
+        early_stopping_params = {} if early_stopping_params is None else early_stopping_params
         self.model = ScoringBasedEmbeddingModel(
             self.eta, self.k, scoring_type=self.model_name, seed=self.seed
         )
@@ -642,25 +648,30 @@ class TransE(ScoringModelBase):
         epochs=100,
         batches_count=100,
         seed=0,
-        embedding_model_params={
-            "corrupt_sides": ["s,o"],
-            "negative_corruption_entities": "all",
-            "norm": 1,
-            "normalize_ent_emb": False,
-        },
+        embedding_model_params=None,
         optimizer="adam",
-        optimizer_params={"lr": 0.0005},
+        optimizer_params=None,
         loss="nll",
-        loss_params={},
+        loss_params=None,
         regularizer=None,
-        regularizer_params={},
+        regularizer_params=None,
         initializer="xavier",
-        initializer_params={"uniform": False},
+        initializer_params=None,
         verbose=False,
         model=None,
     ):
         """Initialize the ScoringBasedEmbeddingModel with the TransE
         scoring function."""
+        embedding_model_params = {
+                "corrupt_sides": ["s,o"],
+                "negative_corruption_entities": "all",
+                "norm": 1,
+                "normalize_ent_emb": False,
+            } if embedding_model_params is None else embedding_model_params
+        optimizer_params = {"lr": 0.0005} if optimizer_params is None else optimizer_params
+        loss_params = {} if loss_params is None else loss_params
+        regularizer_params = {} if regularizer_params is None else regularizer_params
+        initializer_params = {"uniform": False} if initializer_params is None else initializer_params
         super().__init__(
             k,
             eta,
@@ -695,25 +706,30 @@ class DistMult(ScoringModelBase):
         epochs=100,
         batches_count=100,
         seed=0,
-        embedding_model_params={
-            "corrupt_sides": ["s,o"],
-            "negative_corruption_entities": "all",
-            "norm": 1,
-            "normalize_ent_emb": False,
-        },
+        embedding_model_params=None,
         optimizer="adam",
-        optimizer_params={"lr": 0.0005},
+        optimizer_params=None,
         loss="nll",
-        loss_params={},
+        loss_params=None,
         regularizer=None,
-        regularizer_params={},
+        regularizer_params=None,
         initializer="xavier",
-        initializer_params={"uniform": False},
+        initializer_params=None,
         verbose=False,
         model=None,
     ):
         """Initialize the ScoringBasedEmbeddingModel with the DistMult
         scoring function."""
+        embedding_model_params = {
+                "corrupt_sides": ["s,o"],
+                "negative_corruption_entities": "all",
+                "norm": 1,
+                "normalize_ent_emb": False,
+            } if embedding_model_params is None else embedding_model_params
+        optimizer_params = {"lr": 0.0005} if optimizer_params is None else optimizer_params
+        loss_params = {} if loss_params is None else loss_params
+        regularizer_params = {} if regularizer_params is None else regularizer_params
+        initializer_params = {"uniform": False} if initializer_params is None else initializer_params
         super().__init__(
             k,
             eta,
@@ -748,25 +764,30 @@ class ComplEx(ScoringModelBase):
         epochs=100,
         batches_count=100,
         seed=0,
-        embedding_model_params={
-            "corrupt_sides": ["s,o"],
-            "negative_corruption_entities": "all",
-            "norm": 1,
-            "normalize_ent_emb": False,
-        },
+        embedding_model_params=None,
         optimizer="adam",
-        optimizer_params={"lr": 0.0005},
+        optimizer_params=None,
         loss="nll",
-        loss_params={},
+        loss_params=None,
         regularizer=None,
-        regularizer_params={},
+        regularizer_params=None,
         initializer="xavier",
-        initializer_params={"uniform": False},
+        initializer_params=None,
         verbose=False,
         model=None,
     ):
         """Initialize the ScoringBasedEmbeddingModel with the ComplEx
         scoring function."""
+        embedding_model_params = {
+                "corrupt_sides": ["s,o"],
+                "negative_corruption_entities": "all",
+                "norm": 1,
+                "normalize_ent_emb": False,
+            } if embedding_model_params is None else embedding_model_params
+        optimizer_params = {"lr": 0.0005} if optimizer_params is None else optimizer_params
+        loss_params = {} if loss_params is None else loss_params
+        regularizer_params = {} if regularizer_params is None else regularizer_params
+        initializer_params = {"uniform": False} if initializer_params is None else initializer_params
         super().__init__(
             k,
             eta,
@@ -801,25 +822,30 @@ class HolE(ScoringModelBase):
         epochs=100,
         batches_count=100,
         seed=0,
-        embedding_model_params={
-            "corrupt_sides": ["s,o"],
-            "negative_corruption_entities": "all",
-            "norm": 1,
-            "normalize_ent_emb": False,
-        },
+        embedding_model_params=None,
         optimizer="adam",
-        optimizer_params={"lr": 0.0005},
+        optimizer_params=None,
         loss="nll",
-        loss_params={},
+        loss_params=None,
         regularizer=None,
-        regularizer_params={},
+        regularizer_params=None,
         initializer="xavier",
-        initializer_params={"uniform": False},
+        initializer_params=None,
         verbose=False,
         model=None,
     ):
         """Initialize the ScoringBasedEmbeddingModel with the HolE
         scoring function."""
+        embedding_model_params = {
+                "corrupt_sides": ["s,o"],
+                "negative_corruption_entities": "all",
+                "norm": 1,
+                "normalize_ent_emb": False,
+            } if embedding_model_params is None else embedding_model_params
+        optimizer_params = {"lr": 0.0005} if optimizer_params is None else optimizer_params
+        loss_params = {} if loss_params is None else loss_params
+        regularizer_params = {} if regularizer_params is None else regularizer_params
+        initializer_params = {"uniform": False} if initializer_params is None else initializer_params
         super().__init__(
             k,
             eta,

--- a/ampligraph/evaluation/protocol.py
+++ b/ampligraph/evaluation/protocol.py
@@ -456,7 +456,7 @@ def select_best_model_ranking(
     entities_subset=None,
     corrupt_side="s,o",
     focusE=False,
-    focusE_params={},
+    focusE_params=None,
     retrain_best_model=False,
     verbose=False,
 ):
@@ -636,6 +636,7 @@ def select_best_model_ranking(
     >>>                           early_stopping=True)
 
     """
+    focusE_params = {} if focusE_params is None else focusE_params
     from importlib import import_module
 
     from ..compat import evaluate_performance

--- a/ampligraph/latent_features/layers/calibration/calibrate.py
+++ b/ampligraph/latent_features/layers/calibration/calibrate.py
@@ -76,11 +76,12 @@ class CalibrationLayer(tf.keras.layers.Layer):
         self.built = True
 
     def call(
-        self, scores_pos, scores_neg=[], training=0
+        self, scores_pos, scores_neg=None, training=0
     ):
         """
         Call method.
         """
+        scores_neg = [] if scores_neg is None else scores_neg
         if training:
             scores_all = tf.concat([scores_pos, scores_neg], axis=0)
         else:

--- a/ampligraph/latent_features/loss_functions.py
+++ b/ampligraph/latent_features/loss_functions.py
@@ -73,7 +73,7 @@ class Loss(abc.ABC):
     external_params = []
     class_params = {}
 
-    def __init__(self, hyperparam_dict={}, verbose=False):
+    def __init__(self, hyperparam_dict=None, verbose=False):
         """Initialize the loss..
 
         Parameters
@@ -86,6 +86,7 @@ class Loss(abc.ABC):
 
             Other Keys are described in the `hyperparameters` section.
         """
+        hyperparam_dict = {} if hyperparam_dict is None else hyperparam_dict
         self._loss_parameters = {}
         self._loss_parameters["reduction"] = hyperparam_dict.get(
             "reduction", DEFAULT_REDUCTION
@@ -252,7 +253,7 @@ class PairwiseLoss(Loss):
 
     """
 
-    def __init__(self, loss_params={}, verbose=False):
+    def __init__(self, loss_params=None, verbose=False):
         """Initialize the loss.
 
         Parameters
@@ -266,9 +267,10 @@ class PairwiseLoss(Loss):
 
             Example: `loss_params={'margin': 1}`.
         """
+        loss_params = {} if loss_params is None else loss_params
         super().__init__(loss_params, verbose)
 
-    def _init_hyperparams(self, hyperparam_dict={}):
+    def _init_hyperparams(self, hyperparam_dict=None):
         """Verifies and stores the hyperparameters needed by the algorithm.
 
         Parameters
@@ -278,6 +280,7 @@ class PairwiseLoss(Loss):
 
             - `"margin"`: (str) - Margin to be used in pairwise loss computation (default: 1).
         """
+        hyperparam_dict = {} if hyperparam_dict is None else hyperparam_dict
         self._loss_parameters["margin"] = hyperparam_dict.get(
             "margin", DEFAULT_MARGIN
         )
@@ -333,7 +336,7 @@ class NLLLoss(Loss):
     True
     """
 
-    def __init__(self, loss_params={}, verbose=False):
+    def __init__(self, loss_params=None, verbose=False):
         """Initialize the loss..
 
         Parameters
@@ -344,9 +347,10 @@ class NLLLoss(Loss):
             - `"reduction"`: (str) - Specifies whether to `"sum"` or take `"mean"` of loss per sample w.r.t. \
             corruption (default:`"sum"`).
         """
+        loss_params = {} if loss_params is None else loss_params
         super().__init__(loss_params, verbose)
 
-    def _init_hyperparams(self, hyperparam_dict={}):
+    def _init_hyperparams(self, hyperparam_dict=None):
         """Initializes the hyperparameters needed by the algorithm.
 
         Parameters
@@ -354,6 +358,7 @@ class NLLLoss(Loss):
         hyperparam_dict : dictionary
             The Loss will check the keys to get the corresponding parameters.
         """
+        hyperparam_dict = {} if hyperparam_dict is None else hyperparam_dict
         return
 
     @tf.function(experimental_relax_shapes=True)
@@ -408,7 +413,7 @@ class AbsoluteMarginLoss(Loss):
     True
     """
 
-    def __init__(self, loss_params={}, verbose=False):
+    def __init__(self, loss_params=None, verbose=False):
         """Initialize the loss.
 
         Parameters
@@ -422,9 +427,10 @@ class AbsoluteMarginLoss(Loss):
 
             Example: ``loss_params={'margin': 1}``.
         """
+        loss_params = {} if loss_params is None else loss_params
         super().__init__(loss_params, verbose)
 
-    def _init_hyperparams(self, hyperparam_dict={}):
+    def _init_hyperparams(self, hyperparam_dict=None):
         """Initializes the hyperparameters needed by the algorithm.
 
         Parameters
@@ -434,6 +440,7 @@ class AbsoluteMarginLoss(Loss):
 
            `"margin"`: (str) - Margin to be used in loss computation (default: 1).
         """
+        hyperparam_dict = {} if hyperparam_dict is None else hyperparam_dict
         self._loss_parameters["margin"] = hyperparam_dict.get(
             "margin", DEFAULT_MARGIN
         )
@@ -500,7 +507,7 @@ class SelfAdversarialLoss(Loss):
     True
     """
 
-    def __init__(self, loss_params={}, verbose=False):
+    def __init__(self, loss_params=None, verbose=False):
         """Initialize the loss.
 
         Parameters
@@ -516,9 +523,10 @@ class SelfAdversarialLoss(Loss):
             Example: `loss_params={'margin': 1, 'alpha': 0.5}`.
 
         """
+        loss_params = {} if loss_params is None else loss_params
         super().__init__(loss_params, verbose)
 
-    def _init_hyperparams(self, hyperparam_dict={}):
+    def _init_hyperparams(self, hyperparam_dict=None):
         """Initializes the hyperparameters needed by the algorithm.
 
         Parameters
@@ -529,6 +537,7 @@ class SelfAdversarialLoss(Loss):
             - `"margin"`` (int) - Margin to be used in adversarial loss computation (default: 3).
             - `"alpha"`: (float) - Temperature of sampling (default: 0.5).
         """
+        hyperparam_dict = {} if hyperparam_dict is None else hyperparam_dict
         self._loss_parameters["margin"] = hyperparam_dict.get(
             "margin", DEFAULT_MARGIN_ADVERSARIAL
         )
@@ -602,7 +611,7 @@ class NLLMulticlass(Loss):
 
     """
 
-    def __init__(self, loss_params={}, verbose=False):
+    def __init__(self, loss_params=None, verbose=False):
         """Initialize the loss.
 
         Parameters
@@ -614,9 +623,10 @@ class NLLMulticlass(Loss):
              corruption (default: `"sum"`).
 
         """
+        loss_params = {} if loss_params is None else loss_params
         super().__init__(loss_params, verbose)
 
-    def _init_hyperparams(self, hyperparam_dict={}):
+    def _init_hyperparams(self, hyperparam_dict=None):
         """Verifies and stores the hyperparameters needed by the algorithm.
 
         Parameters
@@ -624,6 +634,7 @@ class NLLMulticlass(Loss):
         hyperparam_dict : dict
             The Loss will check the keys to get the corresponding parameters.
         """
+        hyperparam_dict = {} if hyperparam_dict is None else hyperparam_dict
         pass
 
     @tf.function(experimental_relax_shapes=True)
@@ -687,7 +698,7 @@ class LossFunctionWrapper(Loss):
         self._user_losses = user_defined_loss
         self.name = name
 
-    def _init_hyperparams(self, hyperparam_dict={}):
+    def _init_hyperparams(self, hyperparam_dict=None):
         """Verifies and stores the hyperparameters needed by the algorithm.
 
         Parameters
@@ -695,6 +706,7 @@ class LossFunctionWrapper(Loss):
         hyperparam_dict : dict
             The Loss will check the keys to get the corresponding parameters.
         """
+        hyperparam_dict = {} if hyperparam_dict is None else hyperparam_dict
         pass
 
     @tf.function(experimental_relax_shapes=True)
@@ -717,7 +729,7 @@ class LossFunctionWrapper(Loss):
         return self._user_losses(scores_pos, scores_neg)
 
 
-def get(identifier, hyperparams={}):
+def get(identifier, hyperparams=None):
     """
     Get the loss function specified by the identifier.
 
@@ -750,6 +762,7 @@ def get(identifier, hyperparams={}):
     >>> isinstance(udf_loss, Loss)
     True
     """
+    hyperparams = {} if hyperparams is None else hyperparams
     if isinstance(identifier, Loss):
         return identifier
     elif isinstance(identifier, six.string_types):

--- a/ampligraph/latent_features/models/ScoringBasedEmbeddingModel.py
+++ b/ampligraph/latent_features/models/ScoringBasedEmbeddingModel.py
@@ -473,7 +473,7 @@ class ScoringBasedEmbeddingModel(tf.keras.Model):
         self.train_function = train_function
         return self.train_function
 
-    def get_focusE_params(self, dict_params={}):
+    def get_focusE_params(self, dict_params=None):
         """Get parameters for focusE.
 
         Parameters
@@ -496,6 +496,7 @@ class ScoringBasedEmbeddingModel(tf.keras.Model):
             structure weight (`float`).
 
         """
+        dict_params = {} if dict_params is None else dict_params
         # Get the non-linearity function
         non_linearity = dict_params.get("non_linearity", "linear")
         if non_linearity == "linear":
@@ -568,7 +569,7 @@ class ScoringBasedEmbeddingModel(tf.keras.Model):
         validation_entities_subset=None,
         partitioning_k=1,
         focusE=False,
-        focusE_params={},
+        focusE_params=None,
     ):
         """Fit the model on the provided data.
 
@@ -717,6 +718,7 @@ class ScoringBasedEmbeddingModel(tf.keras.Model):
         val_mr: 1074.8920 - val_hits@1: 0.0000e+00 - val_hits@10: 0.2386 - val_hits@100: 0.4773
 
         """
+        focusE_params = {} if focusE_params is None else focusE_params
         # verifies if compile has been called before calling fit
         self._assert_compile_was_called()
         # focusE

--- a/ampligraph/latent_features/optimizers.py
+++ b/ampligraph/latent_features/optimizers.py
@@ -54,7 +54,7 @@ class OptimizerWrapper(abc.ABC):
     def set_partitioned_training(self, value=True):
         self.is_partitioned_training = value
 
-    def minimize(self, loss, ent_emb, rel_emb, gradient_tape, other_vars=[]):
+    def minimize(self, loss, ent_emb, rel_emb, gradient_tape, other_vars=None):
         """Minimizes the loss with respect to entity and relation embeddings and other trainable variables.
 
         Parameters
@@ -70,6 +70,7 @@ class OptimizerWrapper(abc.ABC):
         other_vars: list
             List of all the other trainable variables.
         """
+        other_vars = [] if other_vars is None else other_vars
         all_trainable_vars = [ent_emb, rel_emb]
         all_trainable_vars.extend(other_vars)
         # Total number of trainable variables in the graph

--- a/ampligraph/latent_features/regularizers.py
+++ b/ampligraph/latent_features/regularizers.py
@@ -11,7 +11,7 @@ from functools import partial
 import tensorflow as tf
 
 
-def LP_regularizer(trainable_param, regularizer_parameters={}):
+def LP_regularizer(trainable_param, regularizer_parameters=None):
     """Norm :math:`L^{p}` regularizer.
 
     It is passed to the model as the ``entity_relation_regularizer`` argument of the
@@ -32,12 +32,13 @@ def LP_regularizer(trainable_param, regularizer_parameters={}):
         Regularizer instance from the `tf.keras.regularizer` class.
 
     """
+    regularizer_parameters = {} if regularizer_parameters is None else regularizer_parameters
     return regularizer_parameters.get("lambda", 0.00001) * tf.reduce_sum(
         tf.pow(tf.abs(trainable_param), regularizer_parameters.get("p", 2))
     )
 
 
-def get(identifier, hyperparams={}):
+def get(identifier, hyperparams=None):
     """Get the regularizer specified by the identifier.
 
     Parameters
@@ -52,6 +53,7 @@ def get(identifier, hyperparams={}):
         Regularizer instance of the `tf.keras.regularizer` class.
 
     """
+    hyperparams = {} if hyperparams is None else hyperparams
     if isinstance(identifier, str) and identifier == "l3":
         hyperparams["p"] = 3
         identifier = partial(


### PR DESCRIPTION
Using mutable values for default arguments is not a safe practice.
Look at the following very simple example code:

```python
def foo(x, y=[]):
    y.append(x)
    print(y)
```

The function `foo` doesn't do anything very interesting; it just prints the result of `x` appended to `y`. Naively we might expect this to simply print an array containing only `x` every time `foo` is called, like this:

```python
>>> foo(1)
[1]
>>> foo(2)
[2]
```

But that's not what happens!

```python
>>> foo(1)
[1]
>>> foo(2)
[1, 2]
```

The value of `y` is preserved between calls! This might seem surprising, and it is. It's due to the way that scope works for function arguments in Python.

The result is that any default argument value will be preserved between function calls. This is problematic for *mutable* types, including things like `list`, `dict`, and `set`.

Relying on this behavior is unpredictable and generally considered to be unsafe. Most of us who write code like this were not anticipating the surprising behavior, so it's best to fix it.

Our codemod makes an update that looks like this:
```diff
- def foo(x, y=[]):
+ def foo(x, y=None):
+   y = [] if y is None else y
    y.append(x)
    print(y)
```

Using `None` is a much safer default. The new code checks if `None` is passed, and if so uses an empty `list` for the value of `y`. This will guarantee consistent and safe behavior between calls.

<details>
  <summary>More reading</summary>

</details>

I have additional improvements ready for this repo! If you want to see them, leave the comment:
```
@pixeebot next
```
... and I will open a new PR right away!

Powered by: [pixeebot](https://docs.pixee.ai/) (codemod ID: [pixee:python/fix-mutable-params](https://docs.pixee.ai/codemods/python/pixee_python_fix-mutable-params)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7Ccitizenjosh%2FAmpliGraph%7Ceadf9173d3190d1c02abfaa1ca41c5d427e4c116)

<!--{"type":"DRIP","codemod":"pixee:python/fix-mutable-params"}-->